### PR TITLE
Improve geometry handling, add additional compatible field names

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -3,5 +3,5 @@ name=Snap!
 description=Digitize points through snapping photos
 author=OPENGIS.ch
 icon=icon.svg
-version=1.0
+version=1.1
 homepage=https://www.opengis.ch/


### PR DESCRIPTION
The PR adds a few additional field name candidates - image, media, camera - and improves the geometry creation by taking into account presence of Z and M dimensions.

In addition, the plugin insures the DCIM folder exists prior to taking photos (otherwise it simply fails).

@mbernasocchi , as discussed.